### PR TITLE
Add Terraform module for AWS EC2 with k3s

### DIFF
--- a/k3s-ec2-module/.terraform.lock.hcl
+++ b/k3s-ec2-module/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.0.0"
+  constraints = ">= 5.0.0"
+  hashes = [
+    "h1:DhxTTyLjzmC0wRCodYOWkIGwHAYb2Fcg3zFc/3sIpvk=",
+    "zh:16b1bb786719b7ebcddba3ab751b976ebf4006f7144afeebcb83f0c5f41f8eb9",
+    "zh:1fbc08b817b9eaf45a2b72ccba59f4ea19e7fcf017be29f5a9552b623eccc5bc",
+    "zh:304f58f3333dbe846cfbdfc2227e6ed77041ceea33b6183972f3f8ab51bd065f",
+    "zh:4cd447b5c24f14553bd6e1a0e4fea3c7d7b218cbb2316a3d93f1c5cb562c181b",
+    "zh:589472b56be8277558616075fc5480fcd812ba6dc70e8979375fc6d8750f83ef",
+    "zh:5d78484ba43c26f1ef6067c4150550b06fd39c5d4bfb790f92c4a6f7d9d0201b",
+    "zh:5f470ce664bffb22ace736643d2abe7ad45858022b652143bcd02d71d38d4e42",
+    "zh:7a9cbb947aaab8c885096bce5da22838ca482196cf7d04ffb8bdf7fd28003e47",
+    "zh:854df3e4c50675e727705a0eaa4f8d42ccd7df6a5efa2456f0205a9901ace019",
+    "zh:87162c0f47b1260f5969679dccb246cb528f27f01229d02fd30a8e2f9869ba2c",
+    "zh:9a145404d506b52078cd7060e6cbb83f8fc7953f3f63a5e7137d41f69d6317a3",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a4eab2649f5afe06cc406ce2aaf9fd44dcf311123f48d344c255e93454c08921",
+    "zh:bea09141c6186a3e133413ae3a2e3d1aaf4f43466a6a468827287527edf21710",
+    "zh:d7ea2a35ff55ddfe639ab3b04331556b772a8698eca01f5d74151615d9f336db",
+  ]
+}

--- a/k3s-ec2-module/README.md
+++ b/k3s-ec2-module/README.md
@@ -1,0 +1,16 @@
+# Terraform Module: EC2 with K3s and Nginx
+
+This module creates an EC2 instance on AWS, installs K3s Kubernetes and deploys a sample Nginx server.
+
+## Usage
+
+```
+module "k3s_ec2" {
+  source = "./k3s-ec2-module"
+
+  region        = "us-east-1"
+  instance_type = "t3.small"
+}
+```
+
+After `terraform apply` the public IP of the instance is output. You can access Nginx using that IP on port 80.

--- a/k3s-ec2-module/main.tf
+++ b/k3s-ec2-module/main.tf
@@ -1,0 +1,86 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+# Latest Amazon Linux 2 AMI
+data "aws_ami" "amazon_linux" {
+  most_recent = true
+  owners      = ["amazon"]
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-hvm-*-x86_64-gp2"]
+  }
+}
+
+resource "aws_security_group" "k3s" {
+  name_prefix = "k3s-sg-"
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 6443
+    to_port     = 6443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_instance" "k3s" {
+  ami                         = data.aws_ami.amazon_linux.id
+  instance_type               = var.instance_type
+  key_name                    = var.ssh_key_name
+  vpc_security_group_ids      = [aws_security_group.k3s.id]
+  associate_public_ip_address = true
+
+  user_data = <<-EOF
+              #!/bin/bash
+              curl -sfL https://get.k3s.io | sh -
+              export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+              /usr/local/bin/kubectl create deployment nginx --image=nginx:latest
+              /usr/local/bin/kubectl expose deployment nginx --port=80 --type=NodePort
+              EOF
+
+  tags = {
+    Name = "k3s-node"
+  }
+}
+
+output "instance_public_ip" {
+  value = aws_instance.k3s.public_ip
+}

--- a/k3s-ec2-module/outputs.tf
+++ b/k3s-ec2-module/outputs.tf
@@ -1,0 +1,4 @@
+output "public_ip" {
+  description = "Public IP of the EC2 instance running K3s"
+  value       = aws_instance.k3s.public_ip
+}

--- a/k3s-ec2-module/variables.tf
+++ b/k3s-ec2-module/variables.tf
@@ -1,0 +1,16 @@
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "instance_type" {
+  description = "EC2 instance type"
+  type        = string
+  default     = "t2.micro"
+}
+
+variable "ssh_key_name" {
+  description = "Name of an existing AWS key pair to use for SSH"
+  type        = string
+}


### PR DESCRIPTION
## Summary
- add Terraform module that deploys an EC2 instance
- install k3s and deploy Nginx on the instance via user data
- document how to use the module

## Testing
- `terraform init -backend=false`
- `terraform validate`


------
https://chatgpt.com/codex/tasks/task_e_68589f2d071c8321bddeb71935afd683